### PR TITLE
Implement command and sub-command hierarchy 

### DIFF
--- a/cbackup.sh
+++ b/cbackup.sh
@@ -51,7 +51,7 @@ app_blacklist=(
 )
 
 # Select default action based on filename, because we self-replicate to restore.sh in backups
-action="${1:-$([[ "$0" == *"restore"* ]] && echo restore || echo backup)}"
+action="${1:-$([[ "$0" == *"restore"* ]] && echo restore || echo help)}"
 
 # Prints an error in bold red
 function err() {

--- a/cbackup.sh
+++ b/cbackup.sh
@@ -588,7 +588,7 @@ Actions:
 "
 }
 
-# Parse action and any additional options
+# Parse action and additional options
 OPTIND=2
 case $action in
     backup)
@@ -601,7 +601,8 @@ case $action in
                     ;;
             esac
         done
-        shift $((OPTIND-1))
+
+	shift $((OPTIND - 1))
         do_backup
         ;;
     restore)
@@ -614,7 +615,8 @@ case $action in
                     ;;
             esac
         done
-        shift $((OPTIND-1))
+
+        shift $((OPTIND - 1))
         do_restore
         ;;
     help)
@@ -627,7 +629,8 @@ case $action in
                     ;;
             esac
         done
-        shift $((OPTIND-1))
+
+        shift $((OPTIND - 1))
         print_usage
         exit 0
         ;;

--- a/cbackup.sh
+++ b/cbackup.sh
@@ -578,7 +578,7 @@ function do_restore() {
     done
 }
 
-function usage() {
+function print_usage() {
     echo -n "Usage: `basename $0` <ACTION> [OPTIONS]
 
 Actions:
@@ -596,7 +596,7 @@ case $action in
             case $opt in
                 *)
                     warn "Unknown option for '$action': '$OPTARG'"
-                    usage
+                    print_usage
                     exit 1
                     ;;
             esac
@@ -609,7 +609,7 @@ case $action in
             case $opt in
                 *)
                     warn "Unknown option for '$action': '$OPTARG'"
-                    usage
+                    print_usage
                     exit 1
                     ;;
             esac
@@ -622,18 +622,18 @@ case $action in
             case $opt in
                 *)
                     warn "Unknown option for '$action': '$OPTARG'"
-                    usage
+                    print_usage
                     exit 1
                     ;;
             esac
         done
         shift $((OPTIND-1))
-        usage
+        print_usage
         exit 0
         ;;
     *)
         warn "Unknown action: '$action'"
-        usage
+        print_usage
         exit 1
         ;;
 esac

--- a/cbackup.sh
+++ b/cbackup.sh
@@ -579,10 +579,10 @@ function do_restore() {
 }
 
 function print_usage() {
-    echo -n "Usage: `basename $0` <ACTION> [OPTIONS]
+	echo -n "Usage: $(basename "$0") <ACTION> [OPTIONS]
 
 Actions:
-  backup        Perform a system backup
+  backup        Perform a backup
   restore       Restore an existing backup
   help          Show usage
 "

--- a/cbackup.sh
+++ b/cbackup.sh
@@ -578,15 +578,65 @@ function do_restore() {
     done
 }
 
-# Run action
-echo "Performing action '$action'"
-if [[ "$action" == "backup" ]]; then
-    do_backup
-elif [[ "$action" == "restore" ]]; then
-    do_restore
-else
-    die "Unknown action '$action'"
-fi
+function usage() {
+    echo -n "Usage: `basename $0` <ACTION> [OPTIONS]
+
+Actions:
+  backup        Perform a system backup
+  restore       Restore an existing backup
+  help          Show usage
+"
+}
+
+# Parse action and any additional options
+OPTIND=2
+case $action in
+    backup)
+        while getopts ":" opt; do
+            case $opt in
+                *)
+                    warn "Unknown option for '$action': '$OPTARG'"
+                    usage
+                    exit 1
+                    ;;
+            esac
+        done
+        shift $((OPTIND-1))
+        do_backup
+        ;;
+    restore)
+        while getopts ":" opt; do
+            case $opt in
+                *)
+                    warn "Unknown option for '$action': '$OPTARG'"
+                    usage
+                    exit 1
+                    ;;
+            esac
+        done
+        shift $((OPTIND-1))
+        do_restore
+        ;;
+    help)
+        while getopts ":" opt; do
+            case $opt in
+                *)
+                    warn "Unknown option for '$action': '$OPTARG'"
+                    usage
+                    exit 1
+                    ;;
+            esac
+        done
+        shift $((OPTIND-1))
+        usage
+        exit 0
+        ;;
+    *)
+        warn "Unknown action: '$action'"
+        usage
+        exit 1
+        ;;
+esac
 
 # Cleanup
 rm -fr "$tmp_dir"


### PR DESCRIPTION
In the future, cbackup may implement optional arguments for the base actions (`backup`, `restore`, `help`). Let's prepare cbackup to implement hierarchical processing of commands and sub-commands using nested `getopts`. 