### PR TITLE
HACK: restore: Bypass failure during SELinux context parsing

### DIFF
--- a/cbackup.sh
+++ b/cbackup.sh
@@ -455,9 +455,8 @@ function do_restore() {
         # Get SELinux context from the system-created data directory
         # Parsing the output of ls is not ideal, but Termux doesn't come with any
         # tools for this.
-        # TODO: Fix the sporadic failure codes instead of silencing them with a declaration
         # shellcheck disable=SC2012
-        local secontext="$(/system/bin/ls -a1Z "$data_dir" | head -1 | cut -d' ' -f1)"
+        local secontext="$(/system/bin/ls -a1Z "$data_dir" | head -1 | cut -d' ' -f1 || true)"
         dbg "App SELinux context is $secontext"
 
         # Finally, extract the app data


### PR DESCRIPTION
On rare occasions (about 1 : 20), `ls` may return a non-zero code,
causing bash to terminate the shell. The issue appears to be
caused by a second party operating on the same working directory
at the sime time that we execute the `ls` command.

Add `|| true` to the end of the pipeline to bypass the shell
termination. This should be safe to implement since there is no
scenario in which `$data_dir` is empty, nor is there a possibility
that `ls`, `head`, or `cut` can return an error code.